### PR TITLE
Allow `mjs` prettier config files

### DIFF
--- a/lib/workers/repository/config-migration/branch/migrated-data.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.ts
@@ -32,8 +32,10 @@ const prettierConfigFilenames = new Set([
   '.prettierrc.json5',
   '.prettierrc.js',
   '.prettierrc.cjs',
+  '.prettierrc.mjs',
   'prettier.config.js',
   'prettier.config.cjs',
+  'prettier.config.mjs',
   '.prettierrc.toml',
 ]);
 


### PR DESCRIPTION
See here: https://prettier.io/docs/en/configuration.html

Now ESM modules are allowed for prettier config files

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

Allow ESM prettier config
